### PR TITLE
Redis exception

### DIFF
--- a/CONFIG.py
+++ b/CONFIG.py
@@ -65,7 +65,11 @@ if "http://" in REDIS_URL or "https://" in REDIS_URL:
     )
 
 REDIS_DB = redis.Redis.from_url(REDIS_URL)
-
+try:
+    REDIS_DB.ping()
+except redis.ConnectionError:
+    print("Error connecting to Redis. Please check if Redis is running and the REDIS_URL is set correctly.")
+    exit(1)
 
 redis_config = get_config_file("redis.json")
 values = json.loads(open(redis_config, "r").read()).items()

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cp configs/.env .env
 cp configs/cache_times.json cache_times.json
 
 # Optional: custom redis client configuration
-cp configs/redis_config.json redis_config.json
+cp configs/redis.json redis.json
 
 # THen run to ensure it was setup correctly
 python3 rest.py


### PR DESCRIPTION
Add exception when Redis is not available.

Use REDIS_DB.ping() to check if redis is up and running.
